### PR TITLE
"twig.app.conversation" always returns null

### DIFF
--- a/src/Command/PageflowerPageflowDebugCommand.php
+++ b/src/Command/PageflowerPageflowDebugCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class PageflowerPageflowDebugCommand extends ContainerAwareCommand
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function configure()
     {
@@ -34,7 +34,7 @@ PHP_EOL.
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Controller/ReflectionConversationalControllerRepository.php
+++ b/src/Controller/ReflectionConversationalControllerRepository.php
@@ -23,7 +23,7 @@ class ReflectionConversationalControllerRepository implements RepositoryInterfac
     private $entities = array();
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function add(EntityInterface $entity)
     {
@@ -47,7 +47,7 @@ class ReflectionConversationalControllerRepository implements RepositoryInterfac
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function remove(EntityInterface $entity)
     {

--- a/src/Conversation/Conversation.php
+++ b/src/Conversation/Conversation.php
@@ -119,7 +119,7 @@ class Conversation implements EntityInterface
     /**
      * @param int $conversationCount
      *
-     * @deprecated Deprecated since version 1.1.0, to be removed in 2.0.0.
+     * @deprecated Deprecated since version 1.1.0, to be removed in 2.0.0
      */
     public function increaseConversationCount()
     {
@@ -139,7 +139,7 @@ class Conversation implements EntityInterface
     /**
      * @return bool
      *
-     * @deprecated Deprecated since version 1.1.0, to be removed in 2.0.0.
+     * @deprecated Deprecated since version 1.1.0, to be removed in 2.0.0
      */
     public function isFirstTime()
     {

--- a/src/Conversation/ConversationContext.php
+++ b/src/Conversation/ConversationContext.php
@@ -112,7 +112,7 @@ class ConversationContext
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function generateUrl($routeName, $parameters = array(), $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
@@ -171,7 +171,7 @@ class ConversationContext
     /**
      * @return bool
      *
-     * @deprecated Deprecated since version 1.1.0, to be removed in 2.0.0.
+     * @deprecated Deprecated since version 1.1.0, to be removed in 2.0.0
      */
     public function isFirstTime()
     {

--- a/src/Conversation/ConversationRepository.php
+++ b/src/Conversation/ConversationRepository.php
@@ -23,7 +23,7 @@ class ConversationRepository implements RepositoryInterface
     private $conversationCollection;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function add(EntityInterface $entity)
     {
@@ -51,7 +51,7 @@ class ConversationRepository implements RepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function remove(EntityInterface $entity)
     {

--- a/src/Conversation/EndableConversationSpecification.php
+++ b/src/Conversation/EndableConversationSpecification.php
@@ -34,7 +34,7 @@ class EndableConversationSpecification implements SpecificationInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isSatisfiedBy(EntityInterface $entity)
     {

--- a/src/DependencyInjection/Compiler/GeneratePageflowDefinitionsPass.php
+++ b/src/DependencyInjection/Compiler/GeneratePageflowDefinitionsPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class GeneratePageflowDefinitionsPass implements CompilerPassInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/DependencyInjection/Compiler/ReplaceAppVariableDefinitionPass.php
+++ b/src/DependencyInjection/Compiler/ReplaceAppVariableDefinitionPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class ReplaceAppVariableDefinitionPass implements CompilerPassInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/DependencyInjection/Compiler/ReplaceSessionDefinitionPass.php
+++ b/src/DependencyInjection/Compiler/ReplaceSessionDefinitionPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class ReplaceSessionDefinitionPass implements CompilerPassInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/DependencyInjection/Compiler/ReplaceTemplatingGlobalsDefinitionPass.php
+++ b/src/DependencyInjection/Compiler/ReplaceTemplatingGlobalsDefinitionPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class ReplaceTemplatingGlobalsDefinitionPass implements CompilerPassInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {

--- a/src/DependencyInjection/PHPMentorsPageflowerExtension.php
+++ b/src/DependencyInjection/PHPMentorsPageflowerExtension.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class PHPMentorsPageflowerExtension extends Extension
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -33,7 +33,7 @@ class PHPMentorsPageflowerExtension extends Extension
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getAlias()
     {

--- a/src/EventListener/ConversationListener.php
+++ b/src/EventListener/ConversationListener.php
@@ -77,7 +77,7 @@ class ConversationListener implements ConversationContextAwareInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function setConversationContext(ConversationContext $conversationContext)
     {
@@ -129,7 +129,7 @@ class ConversationListener implements ConversationContextAwareInterface
                         } else {
                             throw new \UnexpectedValueException(sprintf(
                                 'Init method "%s" for pageflow "%s" is not callable.',
-                                get_class($conversationalController) . '::' . $initMethod->getName(),
+                                get_class($conversationalController).'::'.$initMethod->getName(),
                                 $pageflow->getPageflowId()
                             ));
                         }
@@ -153,7 +153,7 @@ class ConversationListener implements ConversationContextAwareInterface
                 if (!in_array($conversation->getCurrentPage()->getPageId(), $reflectionConversationalController->getAcceptablePages($action))) {
                     throw new AccessDeniedHttpException(sprintf(
                         'Controller "%s" should be accessed when the current page is one of [ %s ], the actual page is "%s".',
-                        get_class($conversationalController) . '::' . $action,
+                        get_class($conversationalController).'::'.$action,
                         implode(', ', $reflectionConversationalController->getAcceptablePages($action)),
                         $conversation->getCurrentPage()->getPageId()
                     ));

--- a/src/Form/Extension/Conversation/Type/FormTypeConversationExtension.php
+++ b/src/Form/Extension/Conversation/Type/FormTypeConversationExtension.php
@@ -35,7 +35,7 @@ class FormTypeConversationExtension extends AbstractTypeExtension implements Con
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -46,7 +46,7 @@ class FormTypeConversationExtension extends AbstractTypeExtension implements Con
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function finishView(FormView $view, FormInterface $conversationForm, array $options)
     {
@@ -66,11 +66,12 @@ class FormTypeConversationExtension extends AbstractTypeExtension implements Con
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getExtendedType()
     {
         return 'Symfony\Component\Form\Extension\Core\Type\FormType';
+
         return 'form';
     }
 }

--- a/src/Generator/PageflowDefinitionGenerator.php
+++ b/src/Generator/PageflowDefinitionGenerator.php
@@ -212,7 +212,9 @@ class PageflowDefinitionGenerator
                 throw new \LogicException(sprintf(
                     'The value for annotation "%s" must be a one of [ %s ], "%s" is specified.',
                     'PHPMentors\PageflowerBundle\Annotation\Transition',
-                    implode(', ', array_map(function ($pageId) { return sprintf('"%s"', $pageId); }, $this->pages)),
+                    implode(', ', array_map(function ($pageId) {
+                        return sprintf('"%s"', $pageId);
+                    }, $this->pages)),
                     $transition[1]
                 ));
             }

--- a/src/Generator/ReflectionConversationalControllerDefinitionGenerator.php
+++ b/src/Generator/ReflectionConversationalControllerDefinitionGenerator.php
@@ -91,7 +91,9 @@ class ReflectionConversationalControllerDefinitionGenerator
                                 throw new \LogicException(sprintf(
                                     'The value for annotation "%s" must be a one of [ %s ], "%s" is specified.',
                                     get_class($annotation),
-                                    implode(', ', array_map(function ($pageId) { return sprintf('"%s"', $pageId); }, $this->pages)),
+                                    implode(', ', array_map(function ($pageId) {
+                                        return sprintf('"%s"', $pageId);
+                                    }, $this->pages)),
                                     $accept
                                 ));
                             }

--- a/src/PHPMentorsPageflowerBundle.php
+++ b/src/PHPMentorsPageflowerBundle.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class PHPMentorsPageflowerBundle extends Bundle
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function build(ContainerBuilder $container)
     {
@@ -34,7 +34,7 @@ class PHPMentorsPageflowerBundle extends Bundle
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getContainerExtension()
     {

--- a/src/Pageflow/PageflowRepository.php
+++ b/src/Pageflow/PageflowRepository.php
@@ -23,7 +23,7 @@ class PageflowRepository implements RepositoryInterface
     private $pageflows = array();
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function add(EntityInterface $entity)
     {
@@ -55,7 +55,7 @@ class PageflowRepository implements RepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function remove(EntityInterface $entity)
     {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -49,7 +49,7 @@
       <argument type="service" id="phpmentors_pageflower.conversation_bag"/>
     </service>
     <service id="phpmentors_pageflower.conversational_app_variable" class="%phpmentors_pageflower.conversational_app_variable.class%" public="false">
-      <argument type="service" id="service_container"/>
+      <argument type="service" id="phpmentors_pageflower.conversation_context"/>
     </service>
     <service id="phpmentors_pageflower.conversational_global_variables" class="%phpmentors_pageflower.conversational_global_variables.class%" public="false">
       <argument type="service" id="service_container"/>

--- a/src/Session/ConversationBag.php
+++ b/src/Session/ConversationBag.php
@@ -42,7 +42,7 @@ class ConversationBag implements ConversationCollectionInterface, SessionBagInte
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function clear()
     {
@@ -61,7 +61,7 @@ class ConversationBag implements ConversationCollectionInterface, SessionBagInte
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getName()
     {
@@ -69,7 +69,7 @@ class ConversationBag implements ConversationCollectionInterface, SessionBagInte
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getStorageKey()
     {
@@ -77,7 +77,7 @@ class ConversationBag implements ConversationCollectionInterface, SessionBagInte
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function initialize(array &$conversations)
     {

--- a/src/Session/ConversationalSession.php
+++ b/src/Session/ConversationalSession.php
@@ -25,7 +25,7 @@ class ConversationalSession extends Session
     private $conversationName;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function __construct(SessionStorageInterface $storage = null, AttributeBagInterface $attributes = null, FlashBagInterface $flashes = null, ConversationBag $conversations = null)
     {

--- a/src/Templating/ConversationalAppVariable.php
+++ b/src/Templating/ConversationalAppVariable.php
@@ -14,22 +14,24 @@ namespace PHPMentors\PageflowerBundle\Templating;
 
 use PHPMentors\PageflowerBundle\Conversation\ConversationContext;
 use Symfony\Bridge\Twig\AppVariable;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class ConversationalAppVariable extends AppVariable implements ContainerAwareInterface
+class ConversationalAppVariable extends AppVariable
 {
     /**
-     * @var ContainerInterface
+     * @var ConversationContext
+     *
+     * @since Property available since Release 1.4.0
      */
-    private $container;
+    private $conversationContext;
 
     /**
-     * {@inheritDoc}
+     * @param ConversationContext $conversationContext
+     *
+     * @since Method available since Release 1.4.0
      */
-    public function setContainer(ContainerInterface $container = null)
+    public function __construct(ConversationContext $conversationContext)
     {
-        $this->container = $container;
+        $this->conversationContext = $conversationContext;
     }
 
     /**
@@ -37,6 +39,6 @@ class ConversationalAppVariable extends AppVariable implements ContainerAwareInt
      */
     public function getConversation()
     {
-        return $this->container->get('phpmentors_pageflower.conversation_context');
+        return $this->conversationContext;
     }
 }

--- a/tests/Controller/Bundle/TestBundle/Controller/UserRegistrationController.php
+++ b/tests/Controller/Bundle/TestBundle/Controller/UserRegistrationController.php
@@ -21,7 +21,6 @@ use PHPMentors\PageflowerBundle\Annotation\StartPage;
 use PHPMentors\PageflowerBundle\Annotation\Stateful;
 use PHPMentors\PageflowerBundle\Annotation\Transition;
 use PHPMentors\PageflowerBundle\Controller\Bundle\TestBundle\Entity\User;
-use PHPMentors\PageflowerBundle\Controller\Bundle\TestBundle\Form\Type\UserRegistrationType;
 use PHPMentors\PageflowerBundle\Controller\ConversationalControllerInterface;
 use PHPMentors\PageflowerBundle\Conversation\ConversationContext;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -69,7 +68,7 @@ class UserRegistrationController extends Controller implements ConversationalCon
     private $form;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function setConversationContext(ConversationContext $conversationContext)
     {

--- a/tests/Controller/Bundle/TestBundle/DependencyInjection/Configuration.php
+++ b/tests/Controller/Bundle/TestBundle/DependencyInjection/Configuration.php
@@ -21,7 +21,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {

--- a/tests/Controller/Bundle/TestBundle/DependencyInjection/TestExtension.php
+++ b/tests/Controller/Bundle/TestBundle/DependencyInjection/TestExtension.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class TestExtension extends Extension
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/tests/Controller/Bundle/TestBundle/Form/Type/UserRegistrationType.php
+++ b/tests/Controller/Bundle/TestBundle/Form/Type/UserRegistrationType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 class UserRegistrationType extends AbstractType
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -33,7 +33,7 @@ class UserRegistrationType extends AbstractType
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getName()
     {

--- a/tests/Controller/Bundle/TestBundle/Resources/views/UserRegistration/confirmation.html.twig
+++ b/tests/Controller/Bundle/TestBundle/Resources/views/UserRegistration/confirmation.html.twig
@@ -3,6 +3,10 @@
 {% block title %}confirmation{% endblock %}
 
 {% block body %}
+
+<div id="first_name">{{ app.conversation.conversation.attributes.get('user').firstName }}</div>
+<div id="last_name">{{ app.conversation.conversation.attributes.get('user').lastName }}</div>
+
 {{ form_start(form) }}
 {{ form_widget(form) }}
 {{ form_end(form) }}

--- a/tests/Controller/ConversationalControllerTest.php
+++ b/tests/Controller/ConversationalControllerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class ConversationalControllerTest extends WebTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {
@@ -35,7 +35,7 @@ class ConversationalControllerTest extends WebTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function tearDown()
     {
@@ -45,7 +45,7 @@ class ConversationalControllerTest extends WebTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected static function createKernel(array $options = array())
     {

--- a/tests/Controller/ConversationalControllerTest.php
+++ b/tests/Controller/ConversationalControllerTest.php
@@ -78,7 +78,11 @@ class ConversationalControllerTest extends WebTestCase
         $this->assertThat($client->getResponse()->getStatusCode(), $this->equalTo(200));
         $this->assertThat($client->getCrawler()->filter('title')->text(), $this->stringContains('input'));
 
-        $client->submit($client->getCrawler()->selectButton('user_registration[next]')->form());
+        $form = $client->getCrawler()->selectButton('user_registration[next]')->form();
+        $form['user_registration[firstName]'] = 'Atsuhiro';
+        $form['user_registration[lastName]'] = 'Kubo';
+
+        $client->submit($form);
 
         $this->assertThat($client->getResponse()->getStatusCode(), $this->equalTo(302));
 
@@ -86,6 +90,8 @@ class ConversationalControllerTest extends WebTestCase
 
         $this->assertThat($client->getResponse()->getStatusCode(), $this->equalTo(200));
         $this->assertThat($client->getCrawler()->filter('title')->text(), $this->stringContains('confirmation'));
+        $this->assertThat($client->getCrawler()->filterXpath('//*[@id="first_name"]')->text(), $this->stringContains('Atsuhiro'));
+        $this->assertThat($client->getCrawler()->filterXpath('//*[@id="last_name"]')->text(), $this->stringContains('Kubo'));
 
         $client->submit($client->getCrawler()->selectButton('form[next]')->form());
 

--- a/tests/Controller/app/AppKernel.php
+++ b/tests/Controller/app/AppKernel.php
@@ -24,7 +24,7 @@ class AppKernel extends Kernel
     private $config;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function registerBundles()
     {
@@ -37,7 +37,7 @@ class AppKernel extends Kernel
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | BSD-2-Clause

This will fix a problem that the current `ConversationContext` object is unavailable in Twig via the `twig.app.conversation` template variable in Symfony 3 or greater.
