### PR TITLE
Early removal of the conversation parameter from the Request object

### DIFF
--- a/src/EventListener/ConversationListener.php
+++ b/src/EventListener/ConversationListener.php
@@ -102,8 +102,10 @@ class ConversationListener implements ConversationContextAwareInterface
 
                 if ($event->getRequest()->request->has($this->conversationContext->getConversationParameterName())) {
                     $conversationId = $event->getRequest()->request->get($this->conversationContext->getConversationParameterName());
+                    $event->getRequest()->request->remove($this->conversationContext->getConversationParameterName());
                 } elseif ($event->getRequest()->query->has($this->conversationContext->getConversationParameterName())) {
                     $conversationId = $event->getRequest()->query->get($this->conversationContext->getConversationParameterName());
+                    $event->getRequest()->query->remove($this->conversationContext->getConversationParameterName());
                 }
 
                 if (isset($conversationId)) {

--- a/tests/Controller/Bundle/TestBundle/Controller/UserRegistrationController.php
+++ b/tests/Controller/Bundle/TestBundle/Controller/UserRegistrationController.php
@@ -114,6 +114,10 @@ class UserRegistrationController extends Controller implements ConversationalCon
      */
     public function inputPostAction(Request $request)
     {
+        if ($request->request->has($this->conversationContext->getConversationParameterName())) {
+            throw new \LogicException('The conversation parameter must not be in the Request object at this time.');
+        }
+
         $form = $this->createForm('PHPMentors\PageflowerBundle\Controller\Bundle\TestBundle\Form\Type\UserRegistrationType', $this->user, array(
             'action' => $this->generateUrl('test_user_registration_input_post'),
             'method' => 'POST',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | BSD-2-Clause

This introduces early removal of the conversation parameter from the Request object to prevent a validation error with a form with the empty block prefix.
