### PR TITLE
The new 'session' service definition support on Symfony 3.4.3 or later

### DIFF
--- a/src/DependencyInjection/Compiler/ReplaceSessionDefinitionPass.php
+++ b/src/DependencyInjection/Compiler/ReplaceSessionDefinitionPass.php
@@ -22,7 +22,19 @@ class ReplaceSessionDefinitionPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $container->setDefinition('session', $container->getDefinition('phpmentors_pageflower.conversational_session'));
+        $conversationalSessionDefinition = $container->getDefinition('phpmentors_pageflower.conversational_session');
+        $sessionDefinition = $container->getDefinition('session');
+
+        /*
+         * As of version 3.4.39, the 'session.attribute_bag' and 'session.flash_bag' arguments have been removed from the 'session' definition.
+         * See https://github.com/symfony/symfony/pull/36063 for more details.
+         */
+        if (count($sessionDefinition->getArguments()) == 1) {
+            $conversationalSessionDefinition->replaceArgument(1, null);
+            $conversationalSessionDefinition->replaceArgument(2, null);
+        }
+
+        $container->setDefinition('session', $conversationalSessionDefinition);
         $container->removeDefinition('phpmentors_pageflower.conversational_session');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | BSD-2-Clause

This adds support for the new `session` service definition (see https://github.com/symfony/symfony/pull/36063) on Symfony 3.4.3 or later.
